### PR TITLE
add a S3 key prefix

### DIFF
--- a/cwl/config.go
+++ b/cwl/config.go
@@ -21,6 +21,7 @@ type Prospector struct {
 
 type Config struct {
 	S3BucketName           string        `config:"s3_bucket_name"`
+	S3KeyPrefix            string        `config:"s3_key_prefix"`
 	GroupRefreshFrequency  time.Duration `config:"group_refresh_frequency"`
 	StreamRefreshFrequency time.Duration `config:"stream_refresh_frequency"`
 	ReportFrequency        time.Duration `config:"report_frequency"`
@@ -64,6 +65,7 @@ func (config *Config) Validate() error {
 func (config *Config) String() string {
 	return "settings: " +
 		fmt.Sprintf("s3_bucket_name=%s", config.S3BucketName) +
+		fmt.Sprintf("|s3_key_prefix=%s", config.S3KeyPrefix) +
 		fmt.Sprintf("|aws_region=%v", config.AWSRegion) +
 		fmt.Sprintf("|group_refresh_frequency=%v", config.GroupRefreshFrequency) +
 		fmt.Sprintf("|stream_refresh_frequency=%v", config.StreamRefreshFrequency) +

--- a/cwl/config_test.go
+++ b/cwl/config_test.go
@@ -13,6 +13,7 @@ func Test_Config_TopLevel_Full(t *testing.T) {
 		`
 group_refresh_frequency: 1s
 s3_bucket_name: the-bucket-name
+s3_key_prefix: testprefix/
 stream_refresh_frequency: 5s
 report_frequency: 1m
 aws_region: the-aws-region
@@ -22,6 +23,7 @@ aws_region: the-aws-region
 	config := Config{}
 	cfg.Unpack(&config)
 	assert.Equal(t, "the-bucket-name", config.S3BucketName)
+  assert.Equal(t, "testprefix/", config.S3KeyPrefix)
 	assert.Equal(t, time.Second, config.GroupRefreshFrequency)
 	assert.Equal(t, 5*time.Second, config.StreamRefreshFrequency)
 	assert.Equal(t, 1*time.Minute, config.ReportFrequency)

--- a/cwl/config_test.go
+++ b/cwl/config_test.go
@@ -23,7 +23,7 @@ aws_region: the-aws-region
 	config := Config{}
 	cfg.Unpack(&config)
 	assert.Equal(t, "the-bucket-name", config.S3BucketName)
-  assert.Equal(t, "testprefix/", config.S3KeyPrefix)
+	assert.Equal(t, "testprefix/", config.S3KeyPrefix)
 	assert.Equal(t, time.Second, config.GroupRefreshFrequency)
 	assert.Equal(t, 5*time.Second, config.StreamRefreshFrequency)
 	assert.Equal(t, 1*time.Minute, config.ReportFrequency)

--- a/cwl/s3.go
+++ b/cwl/s3.go
@@ -16,6 +16,7 @@ import (
 type S3Registry struct {
 	S3Client   s3iface.S3API
 	BucketName string
+	KeyPrefix  string
 }
 
 // func NewS3Registry(client s3iface.S3API, bucketName string) Registry {
@@ -35,7 +36,7 @@ func (registry *S3Registry) ReadStreamInfo(stream *Stream) error {
 	logp.Info("Fetching registry info for %s", key)
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(registry.BucketName),
-		Key:    aws.String(key),
+		Key:    aws.String(registry.KeyPrefix + key),
 	}
 	result, err := registry.S3Client.GetObject(input)
 	if err != nil {
@@ -86,7 +87,7 @@ func (registry *S3Registry) WriteStreamInfo(stream *Stream) error {
 	input := &s3.PutObjectInput{
 		Body:            buf,
 		Bucket:          aws.String(registry.BucketName),
-		Key:             aws.String(key),
+		Key:             aws.String(registry.KeyPrefix + key),
 		ContentEncoding: aws.String("application/json"),
 		ContentLength:   aws.Int64(int64(buf.Len())),
 	}


### PR DESCRIPTION
@kkentzo I'm hoping you can review and fix any problems, but it should be really close.

A good-faith effort at adding a prefix to the S3 key. I don't even have the toolchain/experience to build/test/run this in golang, hoping you can review it.

The struct entry takes advantage of the empty value if the prefix is missing.