### PR TITLE
Support VPC flow logs

### DIFF
--- a/cloudwatchlogsbeat.full.yml
+++ b/cloudwatchlogsbeat.full.yml
@@ -54,6 +54,8 @@ cloudwatchlogsbeat:
         pattern: "^REPORT RequestId.+"
         negate: true
         match: before
+      # Add structure to VPC flow logs
+      vpc_flow_log: false
 
 #================================ General ======================================
 

--- a/cwl/config.go
+++ b/cwl/config.go
@@ -17,6 +17,7 @@ type Prospector struct {
 	Id         string     `config:"id"`
 	GroupNames []string   `config:"groupnames"`
 	Multiline  *Multiline `config:"multiline"`
+	VPCFlowLog bool       `config:"vpc_flow_log"`
 }
 
 type Config struct {

--- a/cwl/event.go
+++ b/cwl/event.go
@@ -5,11 +5,7 @@ import (
 	"github.com/elastic/beats/libbeat/publisher"
 )
 
-type Event struct {
-	Stream    *Stream
-	Message   string
-	Timestamp int64
-}
+type Event common.MapStr
 
 type EventPublisher interface {
 	Publish(event *Event)
@@ -21,14 +17,7 @@ type Publisher struct {
 }
 
 func (publisher Publisher) Publish(event *Event) {
-	publisher.Client.PublishEvent(common.MapStr{
-		"@timestamp": common.Time(ToTime(event.Timestamp)),
-		"prospector": event.Stream.Group.Prospector.Id,
-		"type":       event.Stream.Group.Prospector.Id,
-		"message":    event.Message,
-		"group":      event.Stream.Group.Name,
-		"stream":     event.Stream.Name,
-	})
+	publisher.Client.PublishEvent(common.MapStr(*event))
 }
 
 func (publisher Publisher) Close() {

--- a/cwl/multiline_test.go
+++ b/cwl/multiline_test.go
@@ -48,7 +48,7 @@ func Test_Multiline_MatchBefore_NegateTrue(t *testing.T) {
 		func(args mock.Arguments) {
 			event := args.Get(0).(*Event)
 			expectedMessage := createExpectedMessage(events)
-			assert.Equal(t, expectedMessage, event.Message)
+			assert.Equal(t, expectedMessage, (*event)["message"])
 		})
 
 	params := &Params{
@@ -103,7 +103,7 @@ func Test_Multiline_MatchAfter_NegateTrue(t *testing.T) {
 		func(args mock.Arguments) {
 			event := args.Get(0).(*Event)
 			expectedMessage := createExpectedMessage(events)
-			assert.Equal(t, expectedMessage, event.Message)
+			assert.Equal(t, expectedMessage, (*event)["message"])
 		})
 
 	params := &Params{
@@ -156,7 +156,7 @@ func Test_Multiline_MatchBefore_NegateFalse(t *testing.T) {
 		func(args mock.Arguments) {
 			event := args.Get(0).(*Event)
 			expectedMessage := createExpectedMessage(events)
-			assert.Equal(t, expectedMessage, event.Message)
+			assert.Equal(t, expectedMessage, (*event)["message"])
 		})
 
 	params := &Params{
@@ -211,7 +211,7 @@ func Test_Multiline_MatchAfter_NegateFalse(t *testing.T) {
 		func(args mock.Arguments) {
 			event := args.Get(0).(*Event)
 			expectedMessage := createExpectedMessage(events)
-			assert.Equal(t, expectedMessage, event.Message)
+			assert.Equal(t, expectedMessage, (*event)["message"])
 		})
 
 	params := &Params{

--- a/cwl/stream_test.go
+++ b/cwl/stream_test.go
@@ -11,6 +11,47 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func Test_Stream_Digest(t *testing.T) {
+	for _, tt := range []struct {
+		Message string
+		Event   Event
+	}{
+		{
+			"2 342376666950 eni-11ffd826 172.21.83.142 172.21.72.75 2443 47423 6 1 52 1521674216 1521674276 ACCEPT OK",
+			Event{
+				"version":     uint8(2),
+				"accountId":   uint64(342376666950),
+				"interfaceId": "eni-11ffd826",
+				"srcAddr":     "172.21.83.142",
+				"dstAddr":     "172.21.72.75",
+				"srcPort":     uint16(2443),
+				"dstPort":     uint16(47423),
+				"protocol":    uint8(6),
+				"packets":     uint64(1),
+				"bytes":       uint64(52),
+				"start":       time.Unix(1521674216, 0),
+				"end":         time.Unix(1521674276, 0),
+				"action":      "ACCEPT",
+				"logStatus":   "OK",
+			},
+		},
+	} {
+		event, err := parseFlowLogRecord(tt.Message)
+		if err != nil {
+			t.Fatal("Unexpected error")
+		}
+		if len(*event) != len(tt.Event) {
+			t.Fatal("Different length")
+		}
+		for key, actual := range *event {
+			expected := tt.Event[key]
+			if expected != actual {
+				t.Fatalf("Mismatch for %s. Expected:%s, actual:%s", key, expected, actual)
+			}
+		}
+	}
+}
+
 func Test_Stream_Next_WillGenerateCorrectNumberOfEvents(t *testing.T) {
 	group := &Group{
 		Name:       "group",


### PR DESCRIPTION
This allows a user to specify that the cloudwatch logs contain VPC flow log records. It adds structure to the flow logs so they can be easily searched.